### PR TITLE
[Update] Rename ResetHonkStatus

### DIFF
--- a/src/HonkBot/modules/HonkCommandModule/commands/HandleSetHonkStatus.cs
+++ b/src/HonkBot/modules/HonkCommandModule/commands/HandleSetHonkStatus.cs
@@ -12,8 +12,8 @@ public partial class HonkCommandModule : InteractionModuleBase
     /// <param name="status">The status to set.</param>
     /// <param name="activityType">The type of activity to show.</param>
     [DefaultMemberPermissions(GuildPermission.Administrator)]
-    [SlashCommand("reset-honk-status", "Reset honk's status")]
-    public async Task HandleResetHonkStatus(
+    [SlashCommand("set-honk-status", "Set honk's status")]
+    public async Task HandleSetHonkStatus(
         [Summary(description: "The status you want to set for HonkBot.")]
         string status = "honking away",
         [Summary(description: "The type of activity you want to show."), Choice("Playing", 0), Choice("Streaming", 1), Choice("Listening", 2), Choice("Watching", 3), Choice("Competing", 5)]


### PR DESCRIPTION
Renaming `HandleResetHonkStatus` to `HandleSetHonkStatus` since it's not technically _resetting_ the status and is just setting to whatever it is set to.