### PR TITLE
[Update] Modified how dependency versions are resolved

### DIFF
--- a/src/HonkBot/HonkBot.csproj
+++ b/src/HonkBot/HonkBot.csproj
@@ -28,22 +28,22 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Discord.Net" Version="3.8.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+    <PackageReference Include="Discord.Net" Version="3.8.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.*" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.*" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.*" />
   </ItemGroup>
 
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('macOS')) == 'false'">
-    <PackageReference Include="Magick.NET-Q8-x64" Version="12.2.0" />
+    <PackageReference Include="Magick.NET-Q8-x64" Version="12.2.*" />
   </ItemGroup>
 
   <ItemGroup Condition="$([MSBuild]::IsOSPlatform('macOS')) == 'true'">
-    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="12.2.0" />
+    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="12.2.*" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- All **Microsoft.Extensions.*** packages are now resolved to any `6.*` release.
- **Discord.Net** is now resolved to `3.8.*` and **Magick.NET** is now resolved to `12.2.*`. This is to _hopefully_ prevent any breaking changes being applied by the packages, but to still allow for bug fixes.