### PR TITLE
[Bug fix] Getting music share links breaks if an item is not found

### DIFF
--- a/src/HonkBot/modules/HonkCommandModule/commands/HandleGetMusicShareLinksAsync.cs
+++ b/src/HonkBot/modules/HonkCommandModule/commands/HandleGetMusicShareLinksAsync.cs
@@ -23,10 +23,53 @@ public partial class HonkCommandModule : InteractionModuleBase
 
         MusicEntityItem musicEntityItem = await _odesliService.GetShareLinksAsync(musicShareUrl);
 
-        PlatformEntityLink youtubeLink = musicEntityItem.LinksByPlatform!["youtube"];
-        PlatformEntityLink itunesLink = musicEntityItem.LinksByPlatform!["itunes"];
-        PlatformEntityLink appleMusicLink = musicEntityItem.LinksByPlatform!["appleMusic"];
-        PlatformEntityLink spotifyLink = musicEntityItem.LinksByPlatform!["spotify"];
+        PlatformEntityLink? itunesLink;
+        try
+        {
+            itunesLink = musicEntityItem.LinksByPlatform!["itunes"];
+        }
+        catch
+        {
+            _logger.LogError("No iTunes link found for {musicShareUrl}", musicShareUrl);
+            await FollowupAsync(
+                text: "I was unable to get the necessary information from Odesli. :(",
+                ephemeral: true
+            );
+            return;
+        }
+
+        PlatformEntityLink? youtubeLink;
+        try
+        {
+            youtubeLink = musicEntityItem.LinksByPlatform!["youtube"];
+        }
+        catch
+        {
+            _logger.LogWarning("No YouTube link found for {musicShareUrl}", musicShareUrl);
+            youtubeLink = null;
+        }
+
+        PlatformEntityLink? appleMusicLink;
+        try
+        {
+            appleMusicLink = musicEntityItem.LinksByPlatform!["appleMusic"];
+        }
+        catch
+        {
+            _logger.LogWarning("No Apple Music link found for {musicShareUrl}", musicShareUrl);
+            appleMusicLink = null;
+        }
+
+        PlatformEntityLink? spotifyLink;
+        try
+        {
+            spotifyLink = musicEntityItem.LinksByPlatform!["spotify"];
+        }
+        catch
+        {
+            _logger.LogWarning("No Spotify link found for {musicShareUrl}", musicShareUrl);
+            spotifyLink = null;
+        }
 
         StreamingEntityItem itunes = musicEntityItem.EntitiesByUniqueId![itunesLink.EntityUniqueId!];
 
@@ -34,23 +77,62 @@ public partial class HonkCommandModule : InteractionModuleBase
         HttpResponseMessage responseMessage = await httpClient.GetAsync(itunes.ThumbnailUrl);
         Stream imageStream = await responseMessage.Content.ReadAsStreamAsync();
 
-        ButtonBuilder youtubeButton = new(
-            label: "YouTube",
-            style: ButtonStyle.Link,
-            url: youtubeLink.Url!.ToString()
-        );
+        ButtonBuilder youtubeButton;
+        if (youtubeLink is not null)
+        {
+            youtubeButton = new(
+                label: "YouTube",
+                style: ButtonStyle.Link,
+                url: youtubeLink.Url!.ToString()
+            );
+        }
+        else
+        {
+            youtubeButton = new(
+                label: "YouTube 🚫",
+                style: ButtonStyle.Secondary,
+                isDisabled: true,
+                customId: $"{musicEntityItem.EntityUniqueId}-youtube-disabled"
+            );
+        }
 
-        ButtonBuilder appleMusicButton = new(
-            label: "Apple Music",
-            style: ButtonStyle.Link,
-            url: appleMusicLink.Url!.ToString()
-        );
+        ButtonBuilder appleMusicButton;
+        if (appleMusicLink is not null)
+        {
+            appleMusicButton = new(
+                label: "Apple Music",
+                style: ButtonStyle.Link,
+                url: appleMusicLink.Url!.ToString()
+            );
+        }
+        else
+        {
+            appleMusicButton = new(
+                label: "Apple Music 🚫",
+                style: ButtonStyle.Secondary,
+                isDisabled: true,
+                customId: $"{musicEntityItem.EntityUniqueId}-appleMusic-disabled"
+            );
+        }
 
-        ButtonBuilder spotifyButton = new(
-            label: "Spotify",
-            style: ButtonStyle.Link,
-            url: spotifyLink.Url!.ToString()
-        );
+        ButtonBuilder spotifyButton;
+        if (spotifyLink is not null)
+        {
+            spotifyButton = new(
+                label: "Spotify",
+                style: ButtonStyle.Link,
+                url: spotifyLink.Url!.ToString()
+            );
+        }
+        else
+        {
+            spotifyButton = new(
+                label: "Spotify 🚫",
+                style: ButtonStyle.Secondary,
+                isDisabled: true,
+                customId: $"{musicEntityItem.EntityUniqueId}-spotify-disabled"
+            );
+        }
 
         ButtonBuilder moreLinksButton = new(
             label: "More links",

--- a/src/HonkBot/modules/HonkCommandModule/commands/HandleRefreshMusicShareLinks.cs
+++ b/src/HonkBot/modules/HonkCommandModule/commands/HandleRefreshMusicShareLinks.cs
@@ -1,0 +1,39 @@
+using Discord;
+using Discord.Interactions;
+using Discord.WebSocket;
+using HonkBot.Models.Odesli;
+using HonkBot.Services;
+using Microsoft.Extensions.Logging;
+
+namespace HonkBot.Modules;
+
+public partial class HonkCommandModule : InteractionModuleBase
+{
+    /// <summary>
+    /// Updates the music share links when a user clicks the refresh button component.
+    /// </summary>
+    /// <param name="entityUrl">The Odesli URL for the music item entity.</param>
+    /// <returns></returns>
+    [ComponentInteraction(customId: "refresh-musiclinks-btn-*")]
+    private async Task HandleRefreshMusicShareLinksBtnAsync(string entityUrl)
+    {
+        await Context.Interaction.DeferAsync(
+            ephemeral: false
+        );
+
+        _logger.LogInformation("Refreshing music share links for {url}", entityUrl);
+
+        // Get the music entity item from Odesli.
+        MusicEntityItem musicEntityItem = await GetMusicEntityItemAsync(entityUrl);
+
+        // Generate the music share components.
+        ComponentBuilder linksComponentBuilder = GenerateMusicShareComponents(musicEntityItem);
+
+        // Modify the message with the updated components.
+        await Context.Interaction.ModifyOriginalResponseAsync(
+            messageProps => messageProps.Components = linksComponentBuilder.Build()
+        );
+
+        _logger.LogInformation("Refreshed music share links for {url}", entityUrl);
+    }
+}

--- a/src/HonkBot/modules/HonkCommandModule/helpers/GenerateMusicShareComponents.cs
+++ b/src/HonkBot/modules/HonkCommandModule/helpers/GenerateMusicShareComponents.cs
@@ -1,0 +1,150 @@
+using Discord;
+using Discord.Interactions;
+using HonkBot.Models.Odesli;
+using HonkBot.Services;
+using Microsoft.Extensions.Logging;
+
+namespace HonkBot.Modules;
+
+public partial class HonkCommandModule : InteractionModuleBase
+{
+    /// <summary>
+    /// Generates the components for the music share links.
+    /// </summary>
+    /// <param name="musicEntityItem">The <See cref="MusicEntityItem">MusicEntityItem</See> to generate components for.</param>
+    /// <returns>A <See cref="ComponentBuilder">ComponentBuilder</See> with the music share components.</returns>
+    private ComponentBuilder GenerateMusicShareComponents(MusicEntityItem musicEntityItem)
+    {
+        // Attempt to get the YouTube link for the music item.
+        PlatformEntityLink? youtubeLink;
+        try
+        {
+            youtubeLink = musicEntityItem.LinksByPlatform!["youtube"];
+        }
+        catch
+        {
+            // If the YouTube link is not found, set it to null.
+            _logger.LogWarning("No YouTube link found for {url}", musicEntityItem.PageUrl);
+            youtubeLink = null;
+        }
+
+        // Attempt to get the Apple Music link for the music item.
+        PlatformEntityLink? appleMusicLink;
+        try
+        {
+            appleMusicLink = musicEntityItem.LinksByPlatform!["appleMusic"];
+        }
+        catch
+        {
+            // If the Apple Music link is not found, set it to null.
+            _logger.LogWarning("No Apple Music link found for {url}", musicEntityItem.PageUrl);
+            appleMusicLink = null;
+        }
+
+        // Attempt to get the Spotify link for the music item.
+        PlatformEntityLink? spotifyLink;
+        try
+        {
+            spotifyLink = musicEntityItem.LinksByPlatform!["spotify"];
+        }
+        catch
+        {
+            _logger.LogWarning("No Spotify link found for {url}", musicEntityItem.PageUrl);
+            spotifyLink = null;
+        }
+
+        // Create the YouTube button component.
+        ButtonBuilder youtubeButton;
+        if (youtubeLink is not null)
+        {
+            // If the YouTube link is not null, create a button component with the link.
+            youtubeButton = new(
+                label: "YouTube",
+                style: ButtonStyle.Link,
+                url: youtubeLink.Url!.ToString()
+            );
+        }
+        else
+        {
+            // If the YouTube link is null, create a button component with a disabled label.
+            youtubeButton = new(
+                label: "YouTube",
+                style: ButtonStyle.Secondary,
+                isDisabled: true,
+                emote: new Emoji("🚫"),
+                customId: $"{musicEntityItem.EntityUniqueId}-youtube-disabled"
+            );
+        }
+
+        // Create the Apple Music button component.
+        ButtonBuilder appleMusicButton;
+        if (appleMusicLink is not null)
+        {
+            // If the Apple Music link is not null, create a button component with the link.
+            appleMusicButton = new(
+                label: "Apple Music",
+                style: ButtonStyle.Link,
+                url: appleMusicLink.Url!.ToString()
+            );
+        }
+        else
+        {
+            // If the Apple Music link is null, create a button component with a disabled label.
+            appleMusicButton = new(
+                label: "Apple Music",
+                style: ButtonStyle.Secondary,
+                isDisabled: true,
+                emote: new Emoji("🚫"),
+                customId: $"{musicEntityItem.EntityUniqueId}-appleMusic-disabled"
+            );
+        }
+
+        // Create the Spotify button component.
+        ButtonBuilder spotifyButton;
+        if (spotifyLink is not null)
+        {
+            // If the Spotify link is not null, create a button component with the link.
+            spotifyButton = new(
+                label: "Spotify",
+                style: ButtonStyle.Link,
+                url: spotifyLink.Url!.ToString()
+            );
+        }
+        else
+        {
+            // If the Spotify link is null, create a button component with a disabled label.
+            spotifyButton = new(
+                label: "Spotify",
+                style: ButtonStyle.Secondary,
+                isDisabled: true,
+                emote: new Emoji("🚫"),
+                customId: $"{musicEntityItem.EntityUniqueId}-spotify-disabled"
+            );
+        }
+
+        // Create the "More links" button component.
+        ButtonBuilder moreLinksButton = new(
+            label: "More links",
+            style: ButtonStyle.Link,
+            url: musicEntityItem.PageUrl!.ToString()
+        );
+
+        // Create the return button component.
+        ButtonBuilder refreshButton = new(
+            label: "Refresh",
+            style: ButtonStyle.Secondary,
+            emote: new Emoji("🔄"),
+            customId: $"refresh-musiclinks-btn-{musicEntityItem.PageUrl}"
+        );
+
+        // Create the component builder from the button components.
+        ComponentBuilder linksComponentBuilder = new ComponentBuilder()
+            .WithButton(youtubeButton)
+            .WithButton(appleMusicButton)
+            .WithButton(spotifyButton)
+            .WithButton(moreLinksButton)
+            .WithButton(refreshButton);
+
+        return linksComponentBuilder;
+    }
+}

--- a/src/HonkBot/modules/HonkCommandModule/helpers/GetMusicEntityItem.cs
+++ b/src/HonkBot/modules/HonkCommandModule/helpers/GetMusicEntityItem.cs
@@ -1,0 +1,20 @@
+using Discord;
+using Discord.Interactions;
+using HonkBot.Models.Odesli;
+using HonkBot.Services;
+using Microsoft.Extensions.Logging;
+
+namespace HonkBot.Modules;
+
+public partial class HonkCommandModule : InteractionModuleBase
+{
+    /// <summary>
+    /// Get the <see cref="MusicEntityItem" /> of a given URL.
+    /// </summary>
+    /// <param name="url">URL for a music share link.</param>
+    /// <returns>A <See cref="MusicEntityItem">MusicEntityItem</See>.</returns>
+    private async Task<MusicEntityItem> GetMusicEntityItemAsync(string url)
+    {
+        return await _odesliService.GetShareLinksAsync(url);
+    }
+}

--- a/src/HonkBot/modules/HonkCommandModule/helpers/GetMusicEntityItemAlbumArt.cs
+++ b/src/HonkBot/modules/HonkCommandModule/helpers/GetMusicEntityItemAlbumArt.cs
@@ -1,0 +1,25 @@
+using Discord;
+using Discord.Interactions;
+using HonkBot.Models.Odesli;
+using HonkBot.Services;
+using Microsoft.Extensions.Logging;
+
+namespace HonkBot.Modules;
+
+public partial class HonkCommandModule : InteractionModuleBase
+{
+    /// <summary>
+    /// Get the album art of a given <See cref="StreamingEntityItem" /> in a <see cref="MusicEntityItem" />.
+    /// </summary>
+    /// <param name="streamingEntityItem">The streaming entity item.</param>
+    /// <returns>A stream of the album art image.</returns>
+    private static async Task<Stream> GetMusicEntityItemAlbumArt(StreamingEntityItem streamingEntityItem)
+    {
+        // Get the album art from the streaming entity item.
+        using HttpClient httpClient = new();
+        HttpResponseMessage responseMessage = await httpClient.GetAsync(streamingEntityItem.ThumbnailUrl);
+        Stream imageStream = await responseMessage.Content.ReadAsStreamAsync();
+
+        return imageStream;
+    }
+}


### PR DESCRIPTION
This fixes an issue where HonkBot would not return a response if a link for YouTube, Spotify, or Apple Music wasn't found. It additionally adds a refresh button to the response, if a user wants to update the links later on.

Closes #52 