### PR TITLE
[New feature] Per server configs

### DIFF
--- a/src/HonkBot/HonkBot.csproj
+++ b/src/HonkBot/HonkBot.csproj
@@ -29,6 +29,7 @@
 
   <ItemGroup>
     <PackageReference Include="Discord.Net" Version="3.8.*" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.31.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.*" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.*" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.*" />

--- a/src/HonkBot/Program.cs
+++ b/src/HonkBot/Program.cs
@@ -37,6 +37,7 @@ public class Program
                     );
                     services.AddSingleton<IDiscordService, DiscordService>();
                     services.AddSingleton<IOdesliService, OdesliService>();
+                    services.AddSingleton<ICosmosDbService, CosmosDbService>();
                 }
             )
             .ConfigureLogging(

--- a/src/HonkBot/models/config/RandomFartBombConfig.cs
+++ b/src/HonkBot/models/config/RandomFartBombConfig.cs
@@ -7,6 +7,14 @@ namespace HonkBot.Models.Config;
 /// </summary>
 public class RandomFartBombConfig : IRandomFartBombConfig
 {
+    /// <summary>
+    /// Default constructor for the <see cref="RandomFartBombConfig"/> class.
+    /// </summary>
+    public RandomFartBombConfig()
+    {
+        Enabled = false;
+    }
+
     /// <inheritdoc cref="IRandomFartBombConfig.Enabled"/>
     [JsonPropertyName("enabled")]
     public bool Enabled { get; set; }

--- a/src/HonkBot/models/config/RandomFartBombConfig.cs
+++ b/src/HonkBot/models/config/RandomFartBombConfig.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace HonkBot.Models.Config;
+
+/// <summary>
+/// Configuration for the random fart bomb feature in a specific server.
+/// </summary>
+public class RandomFartBombConfig : IRandomFartBombConfig
+{
+    /// <inheritdoc cref="IRandomFartBombConfig.Enabled"/>
+    [JsonPropertyName("enabled")]
+    public bool Enabled { get; set; }
+}

--- a/src/HonkBot/models/config/RandomReactConfig.cs
+++ b/src/HonkBot/models/config/RandomReactConfig.cs
@@ -7,6 +7,15 @@ namespace HonkBot.Models.Config;
 /// </summary>
 public class RandomReactConfig : IRandomReactConfig
 {
+    /// <summary>
+    /// Default constructor for the <see cref="RandomReactConfig"/> class.
+    /// </summary>
+    public RandomReactConfig()
+    {
+        Enabled = false;
+        PercentChanceToHappen = 10;
+    }
+
     /// <inheritdoc cref="IRandomReactConfig.Enabled"/>
     [JsonPropertyName("enabled")]
     public bool Enabled { get; set; }
@@ -19,7 +28,7 @@ public class RandomReactConfig : IRandomReactConfig
         set => SetPercentChanceToHappen(value);
     }
 
-    private int _percentChanceToHappen = 10;
+    private int _percentChanceToHappen;
 
     /// <summary>
     /// Set the PercentChanceToHappen property.

--- a/src/HonkBot/models/config/RandomReactConfig.cs
+++ b/src/HonkBot/models/config/RandomReactConfig.cs
@@ -1,0 +1,41 @@
+using System.Text.Json.Serialization;
+
+namespace HonkBot.Models.Config;
+
+/// <summary>
+/// Configuration for the random react feature in a specific server.
+/// </summary>
+public class RandomReactConfig : IRandomReactConfig
+{
+    /// <inheritdoc cref="IRandomReactConfig.Enabled"/>
+    [JsonPropertyName("enabled")]
+    public bool Enabled { get; set; }
+
+    /// <inheritdoc cref="IRandomReactConfig.PercentChanceToHappen"/>
+    [JsonPropertyName("percentChanceToHappen")]
+    public int PercentChanceToHappen
+    {
+        get => _percentChanceToHappen;
+        set => SetPercentChanceToHappen(value);
+    }
+
+    private int _percentChanceToHappen = 10;
+
+    /// <summary>
+    /// Set the PercentChanceToHappen property.
+    /// </summary>
+    /// <param name="value">The percentage to set to.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Occurs because the provided value is not between 0 and 100</exception>
+    private void SetPercentChanceToHappen(int value)
+    {
+        // Ensure that the provided value is between 0 and 100.
+        if (value > 100 || value < 0)
+        {
+            // If the value not between 0 and 100, throw an ArgumentOutOfRangeException.
+            throw new ArgumentOutOfRangeException(nameof(value), "'PercentChanceToHappen' must be between 0 and 100.");
+        }
+
+        // Set _percentChanceToHappen to the provided value.
+        _percentChanceToHappen = value;
+    }
+}

--- a/src/HonkBot/models/config/ServerConfig.cs
+++ b/src/HonkBot/models/config/ServerConfig.cs
@@ -13,6 +13,7 @@ public class ServerConfig : IServerConfig
     public ServerConfig()
     {
         Id = Guid.NewGuid().ToString();
+        PartitionKey = "server-config-item";
         RandomReactConfig = new RandomReactConfig();
         RandomFartBombConfig = new RandomFartBombConfig();
     }
@@ -20,6 +21,10 @@ public class ServerConfig : IServerConfig
     /// <inheritdoc cref="IServerConfig.Id"/>
     [JsonPropertyName("id")]
     public string Id { get; }
+
+    /// <inheritdoc cref="IServerConfig.PartitionKey"/>
+    [JsonPropertyName("partitionKey")]
+    public string PartitionKey  { get; }
 
     /// <inheritdoc cref="IServerConfig.GuildId"/>
     [JsonPropertyName("guildId")]

--- a/src/HonkBot/models/config/ServerConfig.cs
+++ b/src/HonkBot/models/config/ServerConfig.cs
@@ -10,10 +10,11 @@ public class ServerConfig : IServerConfig
     /// <summary>
     /// Default constructor for the <see cref="ServerConfig"/> class.
     /// </summary>
-    public ServerConfig()
+    public ServerConfig(ulong guildId)
     {
         Id = Guid.NewGuid().ToString();
         PartitionKey = "server-config-item";
+        GuildId = guildId;
         RandomReactConfig = new RandomReactConfig();
         RandomFartBombConfig = new RandomFartBombConfig();
     }

--- a/src/HonkBot/models/config/ServerConfig.cs
+++ b/src/HonkBot/models/config/ServerConfig.cs
@@ -8,7 +8,17 @@ namespace HonkBot.Models.Config;
 public class ServerConfig : IServerConfig
 {
     /// <summary>
-    /// Default constructor for the <see cref="ServerConfig"/> class.
+    /// Default constructor for <see cref="ServerConfig" />.
+    /// </summary>
+    [JsonConstructor]
+    public ServerConfig()
+    {
+        RandomReactConfig = new();
+        RandomFartBombConfig = new();
+    }
+
+    /// <summary>
+    /// Constructor for <see cref="ServerConfig" /> with a provided guild ID.
     /// </summary>
     public ServerConfig(ulong guildId)
     {
@@ -21,11 +31,11 @@ public class ServerConfig : IServerConfig
 
     /// <inheritdoc cref="IServerConfig.Id"/>
     [JsonPropertyName("id")]
-    public string Id { get; }
+    public string Id { get; set; }
 
     /// <inheritdoc cref="IServerConfig.PartitionKey"/>
     [JsonPropertyName("partitionKey")]
-    public string PartitionKey  { get; }
+    public string PartitionKey  { get; set; }
 
     /// <inheritdoc cref="IServerConfig.GuildId"/>
     [JsonPropertyName("guildId")]
@@ -33,9 +43,9 @@ public class ServerConfig : IServerConfig
 
     /// <inheritdoc cref="IServerConfig.RandomReactConfig"/>
     [JsonPropertyName("randomReactConfig")]
-    public RandomReactConfig RandomReactConfig { get; }
+    public RandomReactConfig RandomReactConfig { get; set; }
 
     /// <inheritdoc cref="IServerConfig.RandomFartBombConfig"/>
     [JsonPropertyName("randomFartBombConfig")]
-    public RandomFartBombConfig RandomFartBombConfig { get; }
+    public RandomFartBombConfig RandomFartBombConfig { get; set; }
 }

--- a/src/HonkBot/models/config/ServerConfig.cs
+++ b/src/HonkBot/models/config/ServerConfig.cs
@@ -31,11 +31,11 @@ public class ServerConfig : IServerConfig
 
     /// <inheritdoc cref="IServerConfig.Id"/>
     [JsonPropertyName("id")]
-    public string Id { get; set; }
+    public string Id { get; set; } = null!;
 
     /// <inheritdoc cref="IServerConfig.PartitionKey"/>
     [JsonPropertyName("partitionKey")]
-    public string PartitionKey  { get; set; }
+    public string PartitionKey { get; set; } = null!;
 
     /// <inheritdoc cref="IServerConfig.GuildId"/>
     [JsonPropertyName("guildId")]

--- a/src/HonkBot/models/config/ServerConfig.cs
+++ b/src/HonkBot/models/config/ServerConfig.cs
@@ -1,0 +1,35 @@
+using System.Text.Json.Serialization;
+
+namespace HonkBot.Models.Config;
+
+/// <summary>
+/// Configurations for a specific Discord server.
+/// </summary>
+public class ServerConfig : IServerConfig
+{
+    /// <summary>
+    /// Default constructor for the <see cref="ServerConfig"/> class.
+    /// </summary>
+    public ServerConfig()
+    {
+        Id = Guid.NewGuid().ToString();
+        RandomReactConfig = new RandomReactConfig();
+        RandomFartBombConfig = new RandomFartBombConfig();
+    }
+
+    /// <inheritdoc cref="IServerConfig.Id"/>
+    [JsonPropertyName("id")]
+    public string Id { get; }
+
+    /// <inheritdoc cref="IServerConfig.GuildId"/>
+    [JsonPropertyName("guildId")]
+    public ulong GuildId { get; set; }
+
+    /// <inheritdoc cref="IServerConfig.RandomReactConfig"/>
+    [JsonPropertyName("randomReactConfig")]
+    public RandomReactConfig RandomReactConfig { get; }
+
+    /// <inheritdoc cref="IServerConfig.RandomFartBombConfig"/>
+    [JsonPropertyName("randomFartBombConfig")]
+    public RandomFartBombConfig RandomFartBombConfig { get; }
+}

--- a/src/HonkBot/models/config/interfaces/IRandomFartBombConfig.cs
+++ b/src/HonkBot/models/config/interfaces/IRandomFartBombConfig.cs
@@ -1,0 +1,12 @@
+namespace HonkBot.Models.Config;
+
+/// <summary>
+/// Interface that defines the configuration for the random fart bomb feature in a specific server.
+/// </summary>
+public interface IRandomFartBombConfig
+{
+    /// <summary>
+    /// Whether the random fart bomb feature is enabled in the server.
+    /// </summary>
+    bool Enabled { get; set; }
+}

--- a/src/HonkBot/models/config/interfaces/IRandomReactConfig.cs
+++ b/src/HonkBot/models/config/interfaces/IRandomReactConfig.cs
@@ -1,0 +1,17 @@
+namespace HonkBot.Models.Config;
+
+/// <summary>
+/// Defines the configuration for the random react feature in a specific server.
+/// </summary>
+public interface IRandomReactConfig
+{
+    /// <summary>
+    /// Whether the random react feature is enabled in the server.
+    /// </summary>
+    bool Enabled { get; set; }
+
+    /// <summary>
+    /// The chance for a message to have a random emote reaction added to it.
+    /// </summary>
+    int PercentChanceToHappen { get; set; }
+}

--- a/src/HonkBot/models/config/interfaces/IServerConfig.cs
+++ b/src/HonkBot/models/config/interfaces/IServerConfig.cs
@@ -11,6 +11,11 @@ public interface IServerConfig
     string Id { get; }
 
     /// <summary>
+    /// The partition key for the database.
+    /// </summary>
+    string PartitionKey { get; }
+
+    /// <summary>
     /// The Discord Server's Guild ID.
     /// </summary>
     ulong  GuildId { get; set; }

--- a/src/HonkBot/models/config/interfaces/IServerConfig.cs
+++ b/src/HonkBot/models/config/interfaces/IServerConfig.cs
@@ -1,0 +1,27 @@
+namespace HonkBot.Models.Config;
+
+/// <summary>
+/// Interface that defines the configurations for a specific Discord server.
+/// </summary>
+public interface IServerConfig
+{
+    /// <summary>
+    /// A unique identifier for the server and it's config.
+    /// </summary>
+    string Id { get; }
+
+    /// <summary>
+    /// The Discord Server's Guild ID.
+    /// </summary>
+    ulong  GuildId { get; set; }
+
+    /// <summary>
+    /// Configuration for the random react feature in a specific server.
+    /// </summary>
+    RandomReactConfig RandomReactConfig { get; }
+
+    /// <summary>
+    /// Configuration for the random fart bomb feature in a specific server.
+    /// </summary>
+    RandomFartBombConfig RandomFartBombConfig { get; }
+}

--- a/src/HonkBot/models/config/interfaces/IServerConfig.cs
+++ b/src/HonkBot/models/config/interfaces/IServerConfig.cs
@@ -8,12 +8,12 @@ public interface IServerConfig
     /// <summary>
     /// A unique identifier for the server and it's config.
     /// </summary>
-    string Id { get; }
+    string Id { get; set; }
 
     /// <summary>
     /// The partition key for the database.
     /// </summary>
-    string PartitionKey { get; }
+    string PartitionKey { get; set; }
 
     /// <summary>
     /// The Discord Server's Guild ID.
@@ -23,10 +23,10 @@ public interface IServerConfig
     /// <summary>
     /// Configuration for the random react feature in a specific server.
     /// </summary>
-    RandomReactConfig RandomReactConfig { get; }
+    RandomReactConfig RandomReactConfig { get; set; }
 
     /// <summary>
     /// Configuration for the random fart bomb feature in a specific server.
     /// </summary>
-    RandomFartBombConfig RandomFartBombConfig { get; }
+    RandomFartBombConfig RandomFartBombConfig { get; set; }
 }

--- a/src/HonkBot/modules/HonkBotConfigCommandModule/HonkBotConfigCommandModule.cs
+++ b/src/HonkBot/modules/HonkBotConfigCommandModule/HonkBotConfigCommandModule.cs
@@ -1,0 +1,48 @@
+using Discord;
+using Discord.Interactions;
+using HonkBot.Models.Config;
+using HonkBot.Services;
+using Microsoft.Extensions.Logging;
+
+namespace HonkBot.Modules;
+
+/// <summary>
+/// Slash command module for configuring HonkBot.
+/// </summary>
+public partial class HonkBotConfigCommandModule : InteractionModuleBase
+{
+    /// <summary>
+    /// <see cref="IDiscordService" /> passed in from dependency injection.
+    /// </summary>
+    private readonly IDiscordService _discordService;
+
+    /// <summary>
+    /// <see cref="IOdesliService" /> passed in from dependency injection.
+    /// </summary>
+    private readonly IOdesliService _odesliService;
+
+    /// <summary>
+    /// An <see cref="ILogger" /> for logging.
+    /// </summary>
+    private readonly ILogger<HonkBotConfigCommandModule> _logger;
+
+    /// <summary>
+    /// <see cref="ICosmosDbService" /> passed in from dependency injection.
+    /// </summary>
+    private readonly ICosmosDbService _cosmosDbService;
+
+    /// <summary>
+    /// Initialize <see cref="HonkBotConfigCommandModule" /> for use.
+    /// </summary>
+    /// <param name="discordService">The <see cref="IDiscordService" /> for dependency injection.</param>
+    /// <param name="odesliService">The <see cref="IOdesliService" /> for dependency injection.</param>
+    /// <param name="logger">The logger assigned to <see cref="HonkBotConfigCommandModule" /> for dependency injection.</param>
+    /// <param name="cosmosDbService">The <see cref="ICosmosDbService" /> for dependency injection.</param>
+    public HonkBotConfigCommandModule(IDiscordService discordService, IOdesliService odesliService, ILogger<HonkBotConfigCommandModule> logger, ICosmosDbService cosmosDbService)
+    {
+        _discordService = discordService;
+        _odesliService = odesliService;
+        _logger = logger;
+        _cosmosDbService = cosmosDbService;
+    }
+}

--- a/src/HonkBot/modules/HonkBotConfigCommandModule/commands/HandleGetServerConfigAsync.cs
+++ b/src/HonkBot/modules/HonkBotConfigCommandModule/commands/HandleGetServerConfigAsync.cs
@@ -1,0 +1,32 @@
+using System.Text;
+using Discord;
+using Discord.Interactions;
+using HonkBot.Models.Config;
+using HonkBot.Services;
+using Microsoft.Extensions.Logging;
+
+namespace HonkBot.Modules;
+
+public partial class HonkBotConfigCommandModule : InteractionModuleBase
+{
+    /// <summary>
+    /// Get the config for the current server.
+    /// </summary>
+    /// <returns></returns>
+    [RequireUserPermission(GuildPermission.Administrator)]
+    [SlashCommand(name: "get-honkbot-config", description: "Gets the server configuration.")]
+    public async Task HandleGetServerConfigAsync()
+    {
+        await DeferAsync();
+
+        ServerConfig serverConfig = await _cosmosDbService.GetServerConfigAsync(Context.Guild.Id);
+
+        StringBuilder outputText = new($"**Randomly add reactions to messages:** `{serverConfig.RandomReactConfig.Enabled}` (`{serverConfig.RandomReactConfig.PercentChanceToHappen}%` chance to occur)");
+        outputText.AppendLine("\n");
+        outputText.AppendLine($"**Randomly drop a fart bomb on a message:** `{serverConfig.RandomFartBombConfig.Enabled}`");
+
+        await FollowupAsync(
+            text: outputText.ToString()
+        );
+    }
+}

--- a/src/HonkBot/modules/HonkBotConfigCommandModule/commands/HandleSetHonkBotConfigAsync.cs
+++ b/src/HonkBot/modules/HonkBotConfigCommandModule/commands/HandleSetHonkBotConfigAsync.cs
@@ -1,0 +1,56 @@
+using System.Text;
+using Discord;
+using Discord.Interactions;
+using HonkBot.Models.Config;
+using HonkBot.Services;
+using Microsoft.Extensions.Logging;
+
+namespace HonkBot.Modules;
+
+public partial class HonkBotConfigCommandModule : InteractionModuleBase
+{
+    /// <summary>
+    /// Enable or disable a HonkBot feature.
+    /// </summary>
+    /// <param name="configItem">The config item to set.</param>
+    /// <param name="enabled">Whether to enable the feature or not.</param>
+    /// <returns></returns>
+    [RequireUserPermission(GuildPermission.Administrator)]
+    [SlashCommand(name: "set-honkbot-config", description: "Set a server configuration item for HonkBot.")]
+    public async Task HandleSetHonkBotConfigAsync(
+        [Summary(name: "configitem", description: "The configuration item to set."), Choice(name: "randomreact", value: "randomreact"), Choice(name: "randomfartbomb", value: "randomfartbomb")]
+        string configItem,
+        [Summary("enabled", "Whether to enable the feature or not.")]
+        bool enabled
+    )
+    {
+        await DeferAsync();
+
+        ServerConfig serverConfig = await _cosmosDbService.GetServerConfigAsync(Context.Guild.Id);
+
+        switch (configItem)
+        {
+            case "randomreact":
+                _logger.LogInformation("Setting random react config to '{enabled}' for guild ID '{guildId}'.", enabled, Context.Guild.Id);
+                serverConfig.RandomReactConfig.Enabled = enabled;
+                break;
+            case "randomfartbomb":
+                _logger.LogInformation("Setting random fart bomb config to '{enabled}' for guild ID '{guildId}'.", enabled, Context.Guild.Id);
+                serverConfig.RandomFartBombConfig.Enabled = enabled;
+                break;
+        }
+
+        StringBuilder outputText = new("Updated config:");
+        outputText.AppendLine("\n");
+        outputText.AppendLine($"**Randomly add reactions to messages:** `{serverConfig.RandomReactConfig.Enabled}` (`{serverConfig.RandomReactConfig.PercentChanceToHappen}%` chance to occur)");
+        outputText.AppendLine("\n");
+        outputText.AppendLine($"**Randomly drop a fart bomb on a message:** `{serverConfig.RandomFartBombConfig.Enabled}`");
+
+        _logger.LogInformation("Updating server config for guild ID '{guildId}'.", Context.Guild.Id);
+        await _cosmosDbService.AddOrUpdateServerConfigAsync(serverConfig);
+
+        await FollowupAsync(
+            text: outputText.ToString()
+        );
+    }
+}

--- a/src/HonkBot/services/CosmosDbService/CosmosDbJsonSerializer.cs
+++ b/src/HonkBot/services/CosmosDbService/CosmosDbJsonSerializer.cs
@@ -1,0 +1,62 @@
+using System.Text.Json;
+using Azure.Core.Serialization;
+using Microsoft.Azure.Cosmos;
+
+namespace HonkBot.Services;
+
+/// <summary>
+/// A custom serializer to serialize and deserialize data for the CosmosDB service.
+/// </summary>
+public class CosmosDbJsonSerializer : CosmosSerializer
+{
+    private readonly JsonObjectSerializer jsonSerializer;
+
+    /// <summary>
+    /// Default constructor for the <see cref="CosmosDbJsonSerializer"/> class.
+    /// </summary>
+    /// <param name="jsonSerializerOptions"></param>
+    public CosmosDbJsonSerializer(JsonSerializerOptions jsonSerializerOptions)
+    {
+        jsonSerializer = new(jsonSerializerOptions);
+    }
+
+    /// <inheritdoc cref="Microsoft.Azure.Cosmos.CosmosSerializer.FromStream"/>
+    public override T FromStream<T>(Stream stream)
+    {
+        using (stream)
+        {
+            if (stream.CanSeek
+                   && stream.Length == 0)
+            {
+                return default!;
+            }
+
+            if (typeof(Stream).IsAssignableFrom(typeof(T)))
+            {
+                return (T)(object)stream;
+            }
+
+            return (T)jsonSerializer.Deserialize(
+                stream: stream,
+                returnType: typeof(T),
+                cancellationToken: default
+            )!;
+        }
+    }
+
+    /// <inheritdoc cref="Microsoft.Azure.Cosmos.CosmosSerializer.ToStream"/>
+    public override Stream ToStream<T>(T input)
+    {
+        MemoryStream streamPayload = new();
+
+        jsonSerializer.Serialize(
+            stream: streamPayload,
+            value: input,
+            inputType: typeof(T),
+            cancellationToken: default
+        );
+        streamPayload.Position = 0;
+
+        return streamPayload;
+    }
+}

--- a/src/HonkBot/services/CosmosDbService/CosmosDbService.cs
+++ b/src/HonkBot/services/CosmosDbService/CosmosDbService.cs
@@ -1,0 +1,45 @@
+using HonkBot.Models.Tools;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace HonkBot.Services;
+
+/// <summary>
+/// An Azure Cosmos DB service that can be used to interact with the database.
+/// </summary>
+public partial class CosmosDbService : ICosmosDbService
+{
+    /// <summary>
+    /// Config data passed in from dependency injection.
+    /// </summary>
+    private readonly IConfiguration _config;
+
+    /// <summary>
+    /// An <see cref="ILogger" /> for logging.
+    /// </summary>
+    private readonly ILogger<CosmosDbService> _logger;
+
+    /// <summary>
+    /// The database ID for the <see cref="CosmosDbService" /> to use.
+    /// </summary>
+    private readonly string _databaseId;
+
+    /// <summary>
+    /// Default constructor for <see cref="CosmosDbService" />.
+    /// </summary>
+    /// <param name="config"></param>
+    /// <param name="logger"></param>
+    public CosmosDbService(IConfiguration config, ILogger<CosmosDbService> logger)
+    {
+        _config = config;
+        _logger = logger;
+        _databaseId = _config.GetValue<string>("CosmosDbDatabaseId");
+
+        _cosmosDbClient = new(
+            connectionString: _config.GetValue<string>("CosmosDbConnectionString")
+        );
+    }
+
+    private CosmosClient _cosmosDbClient;
+}

--- a/src/HonkBot/services/CosmosDbService/CosmosDbService.cs
+++ b/src/HonkBot/services/CosmosDbService/CosmosDbService.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using HonkBot.Models.Tools;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Configuration;
@@ -25,6 +26,10 @@ public partial class CosmosDbService : ICosmosDbService
     /// </summary>
     private readonly string _databaseId;
 
+    private readonly CosmosDbJsonSerializer _cosmosDbJsonSerializer = new(
+        new()
+    );
+
     /// <summary>
     /// Default constructor for <see cref="CosmosDbService" />.
     /// </summary>
@@ -37,7 +42,11 @@ public partial class CosmosDbService : ICosmosDbService
         _databaseId = _config.GetValue<string>("CosmosDbDatabaseId");
 
         _cosmosDbClient = new(
-            connectionString: _config.GetValue<string>("CosmosDbConnectionString")
+            connectionString: _config.GetValue<string>("CosmosDbConnectionString"),
+            clientOptions: new()
+            {
+                Serializer = _cosmosDbJsonSerializer
+            }
         );
     }
 

--- a/src/HonkBot/services/CosmosDbService/interfaces/ICosmosDbService.cs
+++ b/src/HonkBot/services/CosmosDbService/interfaces/ICosmosDbService.cs
@@ -1,0 +1,22 @@
+using HonkBot.Models.Config;
+
+namespace HonkBot.Services;
+
+/// <summary>
+/// Interface that defines the methods for interacting with the Azure CosmosDB database.
+/// </summary>
+public interface ICosmosDbService
+{
+    /// <summary>
+    /// Gets a server config from the database.
+    /// </summary>
+    /// <param name="guildId">The Discord Server guild ID to look up.</param>
+    /// <returns>The <see cref="ServerConfig" /> item.</returns>
+    Task<ServerConfig> GetServerConfigAsync(ulong guildId);
+
+    /// <summary>
+    /// Add or update a server config in the database.
+    /// </summary>
+    /// <param name="serverConfig">The <see cref="ServerConfig" /> to add/update.</param>
+    Task AddOrUpdateServerConfigAsync(ServerConfig serverConfig);
+}

--- a/src/HonkBot/services/CosmosDbService/serverconfig/AddOrUpdateServerConfigAsync.cs
+++ b/src/HonkBot/services/CosmosDbService/serverconfig/AddOrUpdateServerConfigAsync.cs
@@ -28,13 +28,10 @@ public partial class CosmosDbService : ICosmosDbService
         catch (CosmosException dbException) when (dbException.StatusCode == HttpStatusCode.NotFound)
         {
             _logger.LogInformation("Server config for guild ID '{guildId}' not found. Creating new entry in database.", serverConfig.GuildId);
-            Stream serverConfigJsonStream = new MemoryStream(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(serverConfig)));
-            string serverConfigJson = JsonSerializer.Serialize(serverConfig);
-            _logger.LogInformation("Server config JSON: {serverConfigJson}", serverConfigJson);
 
             // If the server config doesn't exist in the database already, create it.
-            await container.CreateItemStreamAsync(
-                streamPayload: serverConfigJsonStream,
+            await container.CreateItemAsync(
+                item: serverConfig,
                 partitionKey: new(serverConfig.PartitionKey)
             );
         }

--- a/src/HonkBot/services/CosmosDbService/serverconfig/AddOrUpdateServerConfigAsync.cs
+++ b/src/HonkBot/services/CosmosDbService/serverconfig/AddOrUpdateServerConfigAsync.cs
@@ -1,0 +1,39 @@
+using System.Net;
+using HonkBot.Models.Config;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging;
+
+namespace HonkBot.Services;
+
+public partial class CosmosDbService : ICosmosDbService
+{
+    /// <inheritdoc cref="ICosmosDbService.AddOrUpdateServerConfigAsync(ServerConfig)"/>
+    public async Task AddOrUpdateServerConfigAsync(ServerConfig serverConfig)
+    {
+        Container container = _cosmosDbClient.GetContainer(_databaseId, "server-configs");
+        
+        try
+        {
+            _logger.LogInformation("Updating server config for guild ID '{guildId}'.", serverConfig.GuildId);
+
+            // Attempt to update the server config in the database.
+            await container.ReplaceItemAsync(
+                item: serverConfig,
+                id: serverConfig.Id,
+                partitionKey: new(serverConfig.PartitionKey)
+            );
+        }
+        catch (CosmosException dbException)
+        {
+            _logger.LogInformation("Server config for guild ID '{guildId}' not found. Creating new entry in database.", serverConfig.GuildId);
+            // If the server config doesn't exist in the database already, create it.
+            if (dbException.StatusCode == HttpStatusCode.NotFound)
+            {
+                await container.CreateItemAsync(
+                item: serverConfig,
+                partitionKey: new(serverConfig.PartitionKey)
+            );
+            }
+        }
+    }
+}

--- a/src/HonkBot/services/CosmosDbService/serverconfig/AddOrUpdateServerConfigAsync.cs
+++ b/src/HonkBot/services/CosmosDbService/serverconfig/AddOrUpdateServerConfigAsync.cs
@@ -1,4 +1,6 @@
 using System.Net;
+using System.Text;
+using System.Text.Json;
 using HonkBot.Models.Config;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Logging;
@@ -11,10 +13,10 @@ public partial class CosmosDbService : ICosmosDbService
     public async Task AddOrUpdateServerConfigAsync(ServerConfig serverConfig)
     {
         Container container = _cosmosDbClient.GetContainer(_databaseId, "server-configs");
-        
+
         try
         {
-            _logger.LogInformation("Updating server config for guild ID '{guildId}'.", serverConfig.GuildId);
+            _logger.LogInformation("Updating server config ({id}) for guild ID '{guildId}'.", serverConfig.Id, serverConfig.GuildId);
 
             // Attempt to update the server config in the database.
             await container.ReplaceItemAsync(
@@ -23,17 +25,18 @@ public partial class CosmosDbService : ICosmosDbService
                 partitionKey: new(serverConfig.PartitionKey)
             );
         }
-        catch (CosmosException dbException)
+        catch (CosmosException dbException) when (dbException.StatusCode == HttpStatusCode.NotFound)
         {
             _logger.LogInformation("Server config for guild ID '{guildId}' not found. Creating new entry in database.", serverConfig.GuildId);
+            Stream serverConfigJsonStream = new MemoryStream(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(serverConfig)));
+            string serverConfigJson = JsonSerializer.Serialize(serverConfig);
+            _logger.LogInformation("Server config JSON: {serverConfigJson}", serverConfigJson);
+
             // If the server config doesn't exist in the database already, create it.
-            if (dbException.StatusCode == HttpStatusCode.NotFound)
-            {
-                await container.CreateItemAsync(
-                item: serverConfig,
+            await container.CreateItemStreamAsync(
+                streamPayload: serverConfigJsonStream,
                 partitionKey: new(serverConfig.PartitionKey)
             );
-            }
         }
     }
 }

--- a/src/HonkBot/services/CosmosDbService/serverconfig/GetServerConfigAsync.cs
+++ b/src/HonkBot/services/CosmosDbService/serverconfig/GetServerConfigAsync.cs
@@ -1,0 +1,40 @@
+using HonkBot.Models.Config;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Logging;
+
+namespace HonkBot.Services;
+
+public partial class CosmosDbService : ICosmosDbService
+{
+    /// <inheritdoc cref="ICosmosDbService.GetServerConfigAsync(ulong)"/>
+    /// <exception cref="Exception">Thrown when the database fails to return a result.</exception>
+    public async Task<ServerConfig> GetServerConfigAsync(ulong guildId)
+    {
+        _logger.LogInformation("Getting server config for guild ID '{guildId}'.", guildId);
+        List<ServerConfig> serverConfigs = new();
+
+        // Create a query to get the server config from the database.
+        Container container = _cosmosDbClient.GetContainer(_databaseId, "server-configs");
+        QueryDefinition queryDef = new($"SELECT * FROM c WHERE c.guildId = {guildId}");
+        FeedIterator<ServerConfig> queryResults = container.GetItemQueryIterator<ServerConfig>(queryDef);
+
+        // Iterate through the results and add them to the list.
+        while (queryResults.HasMoreResults)
+        {
+            foreach (ServerConfig serverConfig in await queryResults.ReadNextAsync())
+            {
+                serverConfigs.Add(serverConfig);
+            }
+        }
+
+        // If there are no results, throw an exception.
+        if (serverConfigs.Count == 0)
+        {
+            _logger.LogError("No server config found for guild ID '{guildId}'.", guildId);
+            throw new Exception($"No server config found for guild ID '{guildId}'.");
+        }
+
+        // Only return the first result as there should only be one.
+        return serverConfigs.FirstOrDefault()!;
+    }
+}

--- a/src/HonkBot/services/DiscordService/DiscordService.cs
+++ b/src/HonkBot/services/DiscordService/DiscordService.cs
@@ -168,6 +168,10 @@ public class DiscordService : IDiscordService
                 _logger.LogWarning("Server config not found for guild ID '{guildId}'. Creating new config and adding to database.", guild.Id);
                 ServerConfig serverConfig = new(guild.Id);
                 await _cosmosDbService.AddOrUpdateServerConfigAsync(serverConfig);
+
+                await guild.DefaultChannel.SendMessageAsync(
+                    text: "gm I've just been updated to utilize per-server configs. Administrators can run `/get-honkbot-config` and `/set-honkbot-config` to view and modify the config for this server."
+                );
             }
         }
     }
@@ -178,6 +182,10 @@ public class DiscordService : IDiscordService
         _logger.LogInformation("Adding initial server config to database.");
         ServerConfig serverConfig = new(guild.Id);
         await _cosmosDbService.AddOrUpdateServerConfigAsync(serverConfig);
+
+        await guild.DefaultChannel.SendMessageAsync(
+            text: "gm Hello there! I'm HonkBot. There are some per-server configs that can be set for random message events. Administrators can run `/get-honkbot-config` and `/set-honkbot-config` to view and modify the configs for this server."
+        );
     }
 
     /// <summary>


### PR DESCRIPTION
If HonkBot is ever added to another server, we need to have a way to allow server admins the ability to enable/disable the random message events it does (Basically not through a slash, message, or app command).